### PR TITLE
test_process_annex_info_batch: fix test for git-annex 20180719

### DIFF
--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -210,6 +210,7 @@ class TestProcessOnEmptyAnnex(TempAnnexTestCase):
             str(self.tempdir),
         ) as proc:
             proc.writeline('here')
+            proc.readlines(timeout=1,count=2)
             lines_here = proc.readlines(timeout=1, count=2)
             self.assertEqual(lines_here, [
                 'remote annex keys: 0',


### PR DESCRIPTION
Since git-annex 20180719 the `git-annex info` command displays UUID and
description when a repository is identified by uuid.

This broke the test_process_annex_info_batch case which parses the
output of `git-annex info` output.

See https://git-annex.branchable.com/news/version_6.20180719/